### PR TITLE
Allow multi-line CSVs and (optionally) use pandas

### DIFF
--- a/python4knime/src/de/mpicbg/tds/knime/scripting/python/scripts/PythonCSVUtils.py
+++ b/python4knime/src/de/mpicbg/tds/knime/scripting/python/scripts/PythonCSVUtils.py
@@ -5,7 +5,7 @@ from types import *
 # test if pandas is available
 try:
     import pandas as pd
-    import np as np
+    import numpy as np
     have_pandas = True    
 except:
     have_pandas = False

--- a/python4knime/src/de/mpicbg/tds/knime/scripting/python/scripts/PythonCSVUtils.py
+++ b/python4knime/src/de/mpicbg/tds/knime/scripting/python/scripts/PythonCSVUtils.py
@@ -204,9 +204,9 @@ def write_csv(csv_filename, table, write_types):
                 index += 1
                 
             if have_pandas: # pandas is using np types
-                if np.issubdtype(column[index], np.int) or np.issubdtype(column[index], np.long):
+                if np.issubdtype(type(column[index]), np.int) or np.issubdtype(type(column[index]), np.long):
                     types.append("INT")
-                elif np.issubdtype(column[index], np.float):
+                elif np.issubdtype(type(column[index]), np.float):
                     types.append("FLOAT")
                 else:
                     types.append("STRING")


### PR DESCRIPTION
The current version of the python scripting nodes does not allow/break multi-line CSVs.

The curent approach is to init an empty table (dict of lists) with  line_count \* [None] entries. However this leads to problems with multi-line CSVs. For example, if there is only one entry in the CSV but this entry is a multi-line string of n lines, the current approach will create a size n list, but create_data_table will only fill the first entry, leaving entries 1..n as None. 

Additionally, I changed the code to use pandas for reading csv if available.
