### PR TITLE
Enable all KNIME Cell Types as long as they are compatible to StringCell

### DIFF
--- a/python4knime/src/de/mpicbg/tds/knime/scripting/python/PythonTableConverter.java
+++ b/python4knime/src/de/mpicbg/tds/knime/scripting/python/PythonTableConverter.java
@@ -123,6 +123,7 @@ public class PythonTableConverter {
                 if (type.equals(IntCell.TYPE)) outputTypes.add("INT");
                 else if (type.equals(DoubleCell.TYPE)) outputTypes.add("FLOAT");
                 else if (type.equals(StringCell.TYPE)) outputTypes.add("STRING");
+                else if (type.isCompatible(StringCell.getPreferredValueClass())) outputTypes.add("STRING");
             }
 
             // The second line is the column types
@@ -146,7 +147,9 @@ public class PythonTableConverter {
                         rowValues.add(a.getDoubleAttribute(dataRow).toString());
                     } else if (colType.equals(IntCell.TYPE)) {
                         rowValues.add(a.getIntAttribute(dataRow).toString());
-                    }
+                    } else {
+                    	rowValues.add(a.getRawValue(dataRow));
+                    }                    
                 }
 
                 // All the columns have been added so write it out


### PR DESCRIPTION
Many KNIME cell types are compatible to StringCell.TYPE (e.g. all molecular cells (SDF, SMILES,...)). The current version of the python scripting extensions however insists that a cell type is >equal< to StringCell.TYPE.
Therefore I changed the check of the cell type to include a case where the cell type is compatible to the StringCell value class.)
I didn't want to break the code in [Attribute.java](https://github.com/knime-mpicbg/knime-scripting/blob/development_2.9/knutils/src/de/mpicbg/tds/knime/knutils/Attribute.java), therefore I'm using getRawValue() instead of getNominalAttribute() to retrieve the cell's value.
