### PR TITLE
Registered deprecated RPortObject type in KNIME's port type registry

### DIFF
--- a/de.mpicbg.knime.scripting.r/META-INF/MANIFEST.MF
+++ b/de.mpicbg.knime.scripting.r/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RSnippet-Node extension for KNIME Workbench
 Bundle-SymbolicName: de.mpicbg.knime.scripting.r; singleton:=true
-Bundle-Version: 5.0.0.qualifier
+Bundle-Version: 5.0.1.qualifier
 Bundle-ClassPath: rsnippet.jar
 Bundle-Activator: de.mpicbg.knime.scripting.r.R4KnimeBundleActivator
 Bundle-Vendor: Max Planck Institute of Molecular Cell Biology and Genetics (MPI-CBG)

--- a/de.mpicbg.knime.scripting.r/plugin.xml
+++ b/de.mpicbg.knime.scripting.r/plugin.xml
@@ -142,11 +142,20 @@
        <portType
              color="#000000"
              hidden="false"
-             name="de.mpicbg.knime.scripting.r.port.RPortType2"
+             name="R Scripting (MPI-CBG)"
              objectClass="de.mpicbg.knime.scripting.r.port.RPortObject2"
              objectSerializer="de.mpicbg.knime.scripting.r.port.RPortObjectSerializer2"
              specClass="de.mpicbg.knime.scripting.r.port.RPortObjectSpec2"
              specSerializer="de.mpicbg.knime.scripting.r.port.RPortObjectSpec2$SpecSerializer">
+       </portType>
+       <portType
+             color="#000000"
+             hidden="true"
+             name="R Scripting (MPI-CBG) (deprecated)"
+             objectClass="de.mpicbg.knime.scripting.r.generic.RPortObject"
+             objectSerializer="de.mpicbg.knime.scripting.r.generic.RPortObject$RPortObjectSerializer"
+             specClass="de.mpicbg.knime.scripting.r.generic.RPortObjectSpec"
+             specSerializer="de.mpicbg.knime.scripting.r.generic.RPortObjectSpec$RPortObjectSpecSerializerSerializer">
        </portType>
     </extension>
     <extension

--- a/de.mpicbg.knime.scripting.r/src/de/mpicbg/knime/scripting/r/generic/RPortObjectSpec.java
+++ b/de.mpicbg.knime.scripting.r/src/de/mpicbg/knime/scripting/r/generic/RPortObjectSpec.java
@@ -60,24 +60,7 @@ public final class RPortObjectSpec implements PortObjectSpec {
      */
     public static PortObjectSpecSerializer<RPortObjectSpec>
     getPortObjectSpecSerializer() {
-        return new PortObjectSpecSerializer<RPortObjectSpec>() {
-            /** {@inheritDoc} */
-            @Override
-            public RPortObjectSpec loadPortObjectSpec(
-                    final PortObjectSpecZipInputStream in)
-                    throws IOException {
-                return INSTANCE;
-            }
-
-
-            /** {@inheritDoc} */
-            @Override
-            public void savePortObjectSpec(final RPortObjectSpec portObjectSpec,
-                                           final PortObjectSpecZipOutputStream out)
-                    throws IOException {
-
-            }
-        };
+        return new RPortObjectSpecSerializerSerializer();
     }
 
 
@@ -87,6 +70,25 @@ public final class RPortObjectSpec implements PortObjectSpec {
     public JComponent[] getViews() {
         return new JComponent[]{};
     }
+
+
+	public static final class RPortObjectSpecSerializerSerializer extends PortObjectSpecSerializer<RPortObjectSpec> {
+		/** {@inheritDoc} */
+		@Override
+		public RPortObjectSpec loadPortObjectSpec(
+		        final PortObjectSpecZipInputStream in)
+		        throws IOException {
+		    return INSTANCE;
+		}
+	
+		/** {@inheritDoc} */
+		@Override
+		public void savePortObjectSpec(final RPortObjectSpec portObjectSpec,
+		                               final PortObjectSpecZipOutputStream out)
+		        throws IOException {
+	
+		}
+	}
 
 
     // just used to debug the port visualization

--- a/de.mpicbg.tds.knime.scripting.r.feature/feature.xml
+++ b/de.mpicbg.tds.knime.scripting.r.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.mpicbg.tds.knime.scripting.r.feature"
       label="KNIME R Scripting extension"
-      version="5.0.000.qualifier"
+      version="5.0.1.qualifier"
       provider-name="Max Planck Institute of Molecular Cell Biology and Genetics (MPI-CBG), Dresden, Germany">
 
    <description url="https://github.com/knime-mpicbg/knime-scripting/wiki">


### PR DESCRIPTION
Despite this type being deprecated it still needs/should be properly registered. This is a hot fix to work around bad error handling in KNIME core, which in KNIME Analytics Platform version 5.2.2 (released yesterday) caused startup errors.

This change here should be done anyway but it's also an urgent fix to circumvent issues reported by users, e.g. in KNIME Forum: https://forum.knime.com/t/knime-modern-ui-not-working-error-during-launching/77880/2